### PR TITLE
JSDBRAMS-277 - Corrige definição de schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Corrige a expressão regular de `TimeString` onde estava sendo permitido que somente a letra Z estivesse presente no texto.
 * Corrige a especificação da API de outages que estava diferente da definição do site.
 * Corrige o link da API de produtos e serviços de v2 para v1 conforme utilização de release candidate.
+* Corrige definição de schema onde os objetos `personalUnarrangedAccountOverdraft` e  `businessUnarrangedAccountOverdraft` estavam definidos como lista.
 
 # v1.0.0-rc5.3
 [19/01/2021]

--- a/documentation/source/swagger/parts/schemas/BusinessUnarrangedAccountOverdraftCompany.yaml
+++ b/documentation/source/swagger/parts/schemas/BusinessUnarrangedAccountOverdraftCompany.yaml
@@ -4,10 +4,8 @@ required:
   - cnpjNumber
   - businessUnarrangedAccountOverdraft
 allOf:
-  - $ref: ./Company.yaml
+  - $ref: "./Company.yaml"
 properties:
   businessUnarrangedAccountOverdraft:
-    type: array
-    items:
-      $ref: ./BusinessUnarrangedAccountOverdraft.yaml
-    description: Lista de adiantamento a depositante
+    $ref: "./BusinessUnarrangedAccountOverdraft.yaml"
+    description: Lista de produtos e serviços referente adiantamento a depositante

--- a/documentation/source/swagger/parts/schemas/PersonalUnarrangedAccountOverdraftCompany.yaml
+++ b/documentation/source/swagger/parts/schemas/PersonalUnarrangedAccountOverdraftCompany.yaml
@@ -4,10 +4,8 @@ required:
   - cnpjNumber
   - personalUnarrangedAccountOverdraft
 allOf:
-  - $ref: ./Company.yaml
+  - $ref: "./Company.yaml"
 properties:
   personalUnarrangedAccountOverdraft:
-    type: array
-    items:
-      $ref: ./PersonalUnarrangedAccountOverdraft.yaml
+    $ref: "./PersonalUnarrangedAccountOverdraft.yaml"
     description: Lista de produtos e serviços referente adiantamento a depositante

--- a/documentation/source/swagger/parts/schemas/ResponseBusinessUnarrangedAccountOverdraft.yaml
+++ b/documentation/source/swagger/parts/schemas/ResponseBusinessUnarrangedAccountOverdraft.yaml
@@ -11,12 +11,12 @@ properties:
       - brand
     properties:
       brand:
-        $ref: ./BusinessUnarrangedAccountOverdraftBrand.yaml
+        $ref: "./BusinessUnarrangedAccountOverdraftBrand.yaml"
         description: Organização titular das dependências.
   links:
-    $ref: ./Links.yaml
+    $ref: "./Links.yaml"
   meta:
-    $ref: ./Meta.yaml
+    $ref: "./Meta.yaml"
 example:
   data:
     brand:
@@ -26,69 +26,70 @@ example:
           cnpjNumber: '45086338000178'
           urlComplementaryList: https://empresaa1.com/branches-banking
           businessUnarrangedAccountOverdraft:
-            - fees:
-                services:
-                  - name: CONCESSAO_ADIANTAMENTO_DEPOSITANTE
-                    code: ADIANT_DEPOSITANTE
-                    chargingTriggerInfo: Levantamento de informações e avaliação de viabilidade
-                      e de riscos para a concessão de crédito em caráter emergencial para
-                      cobertura de saldo devedor em conta de depósitos à vista e de excesso
-                      sobre o limite previamente pactuado de cheque especial, cobrada no máximo
-                      uma vez nos últimos trinta dias
-                    prices:
-                      - interval: 1_FAIXA
-                        value: '500.00'
-                        currency: BRL
-                        customers:
-                          rate: '0.1500'
-                      - interval: 2_FAIXA
-                        value: '860.00'
-                        currency: BRL
-                        customers:
-                          rate: '0.3500'
-                      - interval: 3_FAIXA
-                        value: '1090.40'
-                        currency: BRL
-                        customers:
-                          rate: '0.2000'
-                      - interval: 4_FAIXA
-                        value: '2100.00'
-                        currency: BRL
-                        customers:
-                          rate: '0.3000'
-                    minimum:
-                      value: '430.00'
-                      currency: BRL
-                    maximum:
-                      value: '2200.00'
-                      currency: BRL
-              interestRates:
-                - referentialRateIndexer: SEM_INDEXADOR_TAXA
-                  rate: '0.65'
-                  applications:
+            fees:
+              services:
+                - name: CONCESSAO_ADIANTAMENTO_DEPOSITANTE
+                  code: ADIANT_DEPOSITANTE
+                  chargingTriggerInfo: |-
+                    Levantamento de informações e avaliação de viabilidade
+                    e de riscos para a concessão de crédito em caráter emergencial para
+                    cobertura de saldo devedor em conta de depósitos à vista e de excesso
+                    sobre o limite previamente pactuado de cheque especial, cobrada no máximo
+                    uma vez nos últimos trinta dias
+                  prices:
                     - interval: 1_FAIXA
-                      indexer:
-                        rate: '0.0187'
+                      value: '500.00'
+                      currency: BRL
                       customers:
                         rate: '0.1500'
                     - interval: 2_FAIXA
-                      indexer:
-                        rate: '0.2900'
+                      value: '860.00'
+                      currency: BRL
                       customers:
                         rate: '0.3500'
                     - interval: 3_FAIXA
-                      indexer:
-                        rate: '0.3600'
+                      value: '1090.40'
+                      currency: BRL
                       customers:
                         rate: '0.2000'
                     - interval: 4_FAIXA
-                      indexer:
-                        rate: '0.7990'
+                      value: '2100.00'
+                      currency: BRL
                       customers:
                         rate: '0.3000'
-                  minimumRate: '0.0056'
-                  maximumRate: '0.8565'
-              termsConditions: https://empresaa1.com/business_unarranged_account_overdraft
+                  minimum:
+                    value: '430.00'
+                    currency: BRL
+                  maximum:
+                    value: '2200.00'
+                    currency: BRL
+            interestRates:
+              - referentialRateIndexer: SEM_INDEXADOR_TAXA
+                rate: '0.65'
+                applications:
+                  - interval: 1_FAIXA
+                    indexer:
+                      rate: '0.0187'
+                    customers:
+                      rate: '0.1500'
+                  - interval: 2_FAIXA
+                    indexer:
+                      rate: '0.2900'
+                    customers:
+                      rate: '0.3500'
+                  - interval: 3_FAIXA
+                    indexer:
+                      rate: '0.3600'
+                    customers:
+                      rate: '0.2000'
+                  - interval: 4_FAIXA
+                    indexer:
+                      rate: '0.7990'
+                    customers:
+                      rate: '0.3000'
+                minimumRate: '0.0056'
+                maximumRate: '0.8565'
+            termsConditions: https://empresaa1.com/business_unarranged_account_overdraft
   links:
     self: https://api.banco.com.br/open-banking/products-services/v1/business-unarranged-account-overdraft
     first: https://api.banco.com.br/open-banking/products-services/v1/business-unarranged-account-overdraft

--- a/documentation/source/swagger/parts/schemas/ResponsePersonalUnarrangedAccountOverdraft.yaml
+++ b/documentation/source/swagger/parts/schemas/ResponsePersonalUnarrangedAccountOverdraft.yaml
@@ -11,12 +11,12 @@ properties:
       - brand
     properties:
       brand:
-        $ref: ./PersonalUnarrangedAccountOverdraftBrand.yaml
+        $ref: "./PersonalUnarrangedAccountOverdraftBrand.yaml"
         description: Organização titular das dependências
   links:
-    $ref: ./Links.yaml
+    $ref: "./Links.yaml"
   meta:
-    $ref: ./Meta.yaml
+    $ref: "./Meta.yaml"
 example:
   data:
     brand:
@@ -26,69 +26,70 @@ example:
           cnpjNumber: '50685362000135'
           urlComplementaryList: https://empresadaorganizacaoa.com/complementarylist
           personalUnarrangedAccountOverdraft:
-            - fees:
-                priorityServices:
-                  - name: CONCESSAO_ADIANTAMENTO_DEPOSITANTE
-                    code: ADIANT_DEPOSITANTE
-                    chargingTriggerInfo: Levantamento de informações e avaliação de viabilidade
-                      e de riscos para a concessão de crédito em caráter emergencial para
-                      cobertura de saldo devedor em conta de depósitos à vista e de excesso
-                      sobre o limite previamente pactuado de cheque especial, cobrada no máximo
-                      uma vez nos últimos trinta dias
-                    prices:
-                      - interval: 1_FAIXA
-                        value: '500.00'
-                        currency: BRL
-                        customers:
-                          rate: '0.1500'
-                      - interval: 2_FAIXA
-                        value: '860.00'
-                        currency: BRL
-                        customers:
-                          rate: '0.3500'
-                      - interval: 3_FAIXA
-                        value: '1090.40'
-                        currency: BRL
-                        customers:
-                          rate: '0.2000'
-                      - interval: 4_FAIXA
-                        value: '2100.00'
-                        currency: BRL
-                        customers:
-                          rate: '0.3000'
-                    minimum:
-                      value: '430.00'
-                      currency: BRL
-                    maximum:
-                      value: '2200.00'
-                      currency: BRL
-              interestRates:
-                - referentialRateIndexer: SEM_INDEXADOR_TAXA
-                  rate: '0.65'
-                  applications:
+            fees:
+              priorityServices:
+                - name: CONCESSAO_ADIANTAMENTO_DEPOSITANTE
+                  code: ADIANT_DEPOSITANTE
+                  chargingTriggerInfo: |-
+                    Levantamento de informações e avaliação de viabilidade
+                    e de riscos para a concessão de crédito em caráter emergencial para
+                    cobertura de saldo devedor em conta de depósitos à vista e de excesso
+                    sobre o limite previamente pactuado de cheque especial, cobrada no máximo
+                    uma vez nos últimos trinta dias
+                  prices:
                     - interval: 1_FAIXA
-                      indexer:
-                        rate: '0.0187'
+                      value: '500.00'
+                      currency: BRL
                       customers:
                         rate: '0.1500'
                     - interval: 2_FAIXA
-                      indexer:
-                        rate: '0.2900'
+                      value: '860.00'
+                      currency: BRL
                       customers:
                         rate: '0.3500'
                     - interval: 3_FAIXA
-                      indexer:
-                        rate: '0.3600'
+                      value: '1090.40'
+                      currency: BRL
                       customers:
                         rate: '0.2000'
                     - interval: 4_FAIXA
-                      indexer:
-                        rate: '0.7990'
+                      value: '2100.00'
+                      currency: BRL
                       customers:
                         rate: '0.3000'
-                  minimumRate: '0.0056'
-                  maximumRate: '0.8565'
-              termsConditions: https://empresaa1.com/personal_unarranged_account_overdraft
+                  minimum:
+                    value: '430.00'
+                    currency: BRL
+                  maximum:
+                    value: '2200.00'
+                    currency: BRL
+            interestRates:
+              - referentialRateIndexer: SEM_INDEXADOR_TAXA
+                rate: '0.65'
+                applications:
+                  - interval: 1_FAIXA
+                    indexer:
+                      rate: '0.0187'
+                    customers:
+                      rate: '0.1500'
+                  - interval: 2_FAIXA
+                    indexer:
+                      rate: '0.2900'
+                    customers:
+                      rate: '0.3500'
+                  - interval: 3_FAIXA
+                    indexer:
+                      rate: '0.3600'
+                    customers:
+                      rate: '0.2000'
+                  - interval: 4_FAIXA
+                    indexer:
+                      rate: '0.7990'
+                    customers:
+                      rate: '0.3000'
+                minimumRate: '0.0056'
+                maximumRate: '0.8565'
+            termsConditions: https://empresaa1.com/personal_unarranged_account_overdraft
   links:
     self: https://api.banco.com.br/open-banking/products-services/v1/personal-unarranged-account-overdraft
     first: https://api.banco.com.br/open-banking/products-services/v1/personal-unarranged-account-overdraft


### PR DESCRIPTION
onde os objetos `personalUnarrangedAccountOverdraft` e  `businessUnarrangedAccountOverdraft` estavam definidos como lista.